### PR TITLE
[Hcloud-Kernel] Share memory IO linker

### DIFF
--- a/linux-4.15/ipc/shmid_io_linker.c
+++ b/linux-4.15/ipc/shmid_io_linker.c
@@ -69,3 +69,53 @@ err_putref:
 	return ERR_PTR(retval);
 }
 
+
+
+
+int shmid_alloc_object (struct gdm_obj * obj_entry,
+			struct gdm_set * set,
+			objid_t objid)
+{
+	shmid_object_t *shp_object;
+
+	shp_object = kmem_cache_alloc (shmid_object_cachep, GFP_KERNEL);
+	if (!shp_object)
+		return -ENOMEM;
+
+	shp_object->local_shp = NULL;
+	obj_entry->object = shp_object;
+
+	return 0;
+}
+
+
+int shmid_insert_object (struct gdm_obj * obj_entry,
+			 struct gdm_set * set,
+			 objid_t objid)
+{
+	shmid_object_t *shp_object;
+	struct shmid_kernel *shp;
+	struct ipc_namespace *ns;
+	int r = 0;
+
+	shp_object = obj_entry->object;
+	BUG_ON(!shp_object);
+
+	if (shp_object->local_shp)
+		goto done;
+
+	ns = find_get_hcc_ipcns();
+	BUG_ON(!ns);
+
+	shp = create_local_shp(ns, &shp_object->mobile_shp, shp_object->set_id);
+	shp_object->local_shp = shp;
+
+	if (IS_ERR(shp)) {
+		r = PTR_ERR(shp);
+		BUG();
+	}
+
+	put_ipc_ns(ns);
+done:
+	return r;
+}


### PR DESCRIPTION
    shmid_remove_object
      - find name space and share memory object locking
    
    shmid_invalidate_object
      - return enum value(KDDM_IO_KEEP_OBJECT)    

    shmid_alloc_object
      - Share memory object cache allocation
    
    shmid_insert_object
      - find hcc namespace
      - remotly share memory segment creation

@hcloudclassic 