### PR TITLE
[Hcloud-Kernel] Share memory linker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "list": "c"
-    }
-}

--- a/linux-4.15/.gitignore
+++ b/linux-4.15/.gitignore
@@ -122,3 +122,5 @@ all.config
 
 # Kdevelop4
 *.kdev4
+
+.vscode/

--- a/linux-4.15/ipc/semarray_io_linker.c
+++ b/linux-4.15/ipc/semarray_io_linker.c
@@ -253,3 +253,18 @@ static inline void __export_one_local_semqueue(struct rpc_desc *desc,
 		rpc_pack_type(desc, q->undo->proc_list_id);
 	}
 }
+
+
+static inline void __export_one_remote_semqueue(struct rpc_desc *desc,
+						const struct sem_queue* q)
+{
+	rpc_pack(desc, 0, q, sizeof(struct sem_queue));
+	if (q->nsops)
+		rpc_pack(desc, 0, q->sops,
+			 q->nsops * sizeof(struct sembuf));
+
+	if (q->undo) {
+		BUG_ON(!list_empty(&q->undo->list_proc));
+		rpc_pack_type(desc, q->undo->proc_list_id);
+	}
+}

--- a/linux-4.15/ipc/semarray_io_linker.c
+++ b/linux-4.15/ipc/semarray_io_linker.c
@@ -236,3 +236,20 @@ static inline void __export_semundos(struct rpc_desc *desc,
 			 sma->sem_nsems * sizeof(short));
 	}
 }
+
+
+static inline void __export_one_local_semqueue(struct rpc_desc *desc,
+					       const struct sem_queue* q)
+{
+	struct sem_queue q2 = *q;
+	q2.sleeper = (void*)((long)(task_pid_knr(q->sleeper)));
+	rpc_pack_type(desc, q2);
+	if (q->nsops)
+		rpc_pack(desc, 0, q->sops,
+			 q->nsops * sizeof(struct sembuf));
+
+	if (q->undo) {
+		BUG_ON(!list_empty(&q->undo->list_proc));
+		rpc_pack_type(desc, q->undo->proc_list_id);
+	}
+}


### PR DESCRIPTION
semarray_remove_object
  - find array at ipc namespace
  - hcc object free

__export_semarray
  - semaphore array export via rpc

__export_semundos
  - export via rpc, semaphore undo list and namespace

__export_one_local_semqueue
  - export local semaphore queue
  - rpc_packing

__export_one_remote_semqueue
  - sepcific sem queue export

__export_semqueues
  - rpcpacking queue

semarray_export_object
  - sem obj allocate local semaphore

@hcloudclassic 
