### PR TITLE
[Hcloud-Kernel] Share memory linker, Semaphore Undo List Linker

### DIFF
--- a/linux-4.15/ipc/semarray_io_linker.c
+++ b/linux-4.15/ipc/semarray_io_linker.c
@@ -518,3 +518,8 @@ struct iolinker_struct semarray_linker = {
 	export_object:     semarray_export_object,
 	import_object:     semarray_import_object
 };
+
+struct iolinker_struct semkey_linker = {
+	linker_name:       "semkey",
+	linker_id:         SEMKEY_LINKER,
+};

--- a/linux-4.15/ipc/semarray_io_linker.c
+++ b/linux-4.15/ipc/semarray_io_linker.c
@@ -506,3 +506,15 @@ unimport_semundos:
 err:
 	return r;
 }
+
+struct iolinker_struct semarray_linker = {
+	first_touch:       semarray_first_touch,
+	remove_object:     semarray_remove_object,
+	invalidate_object: semarray_invalidate_object,
+	insert_object:     semarray_insert_object,
+	linker_name:       "semarray",
+	linker_id:         SEMARRAY_LINKER,
+	alloc_object:      semarray_alloc_object,
+	export_object:     semarray_export_object,
+	import_object:     semarray_import_object
+};

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -21,3 +21,14 @@ static inline void __undolist_remove(struct semundo_list_object *undo_list)
 		undo_list->list = NULL;
 	}
 }
+
+static inline struct semundo_list_object * __undolist_alloc(void)
+{
+	struct semundo_list_object *undo_list;
+
+	undo_list = kzalloc(sizeof(struct semundo_list_object), GFP_KERNEL);
+	if (!undo_list)
+		return ERR_PTR(-ENOMEM);
+
+	return undo_list;
+}

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -32,3 +32,18 @@ static inline struct semundo_list_object * __undolist_alloc(void)
 
 	return undo_list;
 }
+
+
+int undolist_alloc_object (struct gdm_obj * obj_entry,
+			   struct gdm_set * set,
+			   objid_t objid)
+{
+	struct semundo_list_object *undo_list;
+
+	undo_list = __undolist_alloc();
+	if (IS_ERR(undo_list))
+		return PTR_ERR(undo_list);
+
+	obj_entry->object = undo_list;
+	return 0;
+}s

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -71,3 +71,16 @@ int undolist_remove_object (void *object,
 
 	return 0;
 }
+
+int undolist_invalidate_object (struct gdm_obj * obj_entry,
+				struct gdm_set * set,
+				objid_t objid)
+{
+	struct semundo_list_object *undo_list;
+	undo_list = obj_entry->object;
+
+	__undolist_remove(undo_list);
+	obj_entry->object = NULL;
+
+	return 0;
+}

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -1,0 +1,23 @@
+#include <linux/sem.h>
+#include <linux/lockdep.h>
+#include <linux/security.h>
+#include <linux/ipc.h>
+#include <linux/ipc_namespace.h>
+#include <net/hccrpc/rpc.h>
+#include <gdm/gdm.h>
+
+#include "semundolst_io_linker.h"
+
+
+static inline void __undolist_remove(struct semundo_list_object *undo_list)
+{
+	struct semundo_id *id, *next;
+
+	if (undo_list) {
+		for (id = undo_list->list; id; id = next) {
+			next = id->next;
+			kfree(id);
+		}
+		undo_list->list = NULL;
+	}
+}

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -46,4 +46,13 @@ int undolist_alloc_object (struct gdm_obj * obj_entry,
 
 	obj_entry->object = undo_list;
 	return 0;
-}s
+}
+
+int undolist_first_touch (struct kddm_obj * obj_entry,
+			  struct kddm_set * set,
+			  objid_t objid,
+			  int flags)
+{
+	BUG();
+	return -EINVAL;
+}

--- a/linux-4.15/ipc/semundolst_io_linker.c
+++ b/linux-4.15/ipc/semundolst_io_linker.c
@@ -48,11 +48,26 @@ int undolist_alloc_object (struct gdm_obj * obj_entry,
 	return 0;
 }
 
-int undolist_first_touch (struct kddm_obj * obj_entry,
-			  struct kddm_set * set,
+int undolist_first_touch (struct gdm_obj * obj_entry,
+			  struct gdm_set * set,
 			  objid_t objid,
 			  int flags)
 {
 	BUG();
 	return -EINVAL;
+}
+
+
+int undolist_remove_object (void *object,
+			    struct gdm_set * set,
+			    objid_t objid)
+{
+	struct semundo_list_object *undo_list;
+	undo_list = object;
+
+	__undolist_remove(undo_list);
+	kfree(undo_list);
+	object = NULL;
+
+	return 0;
 }


### PR DESCRIPTION
semarray_linker structure

	linker_id : semarray linkers connected
	export_object : For remote porcess

semkey_linker structure
	semkey is pretty simple logic
	linker array classified linker id

__undolist_remove

checking at semundo_list with object id

__undolist_alloc
  - Before undo list, allocate kernel mem

undolist_alloc_object
  - Kernel mem allocate for object
  - execute undo

undolist_first_touch
  - If Kernel access first undo list, it was not good status
  - All of object, must have own list

undolist_remove_object
  - running remove object

undolist_invalidate_object

undolist_export_object for remote compute node
They have each object list

undolist_import_object

@hcloudclassic 